### PR TITLE
Migrate to Diesel 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4"
-diesel = { version = "1.4.4", features = ["postgres"] }
+diesel = { version = "2.0.0", features = ["postgres"] }
 dotenv = "0.15.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> std::io::Result<()> {
 async fn add_reading(reading: web::Json<models::Reading>) -> Result<String> {
     dotenv().ok();
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    let connection = PgConnection::establish(&database_url)
+    let mut connection = PgConnection::establish(&database_url)
         .expect(&format!("Error connecting to {}", database_url));
 
     let new_reading = models::Reading {
@@ -40,7 +40,7 @@ async fn add_reading(reading: web::Json<models::Reading>) -> Result<String> {
 
     diesel::insert_into(schema::readings::table)
         .values(&new_reading)
-        .execute(&connection)
+        .execute(&mut connection)
         .unwrap();
 
     Ok("Created reading".to_owned())

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,7 +3,7 @@ use diesel::Insertable;
 use serde::Deserialize;
 
 #[derive(Debug, Insertable, Deserialize)]
-#[table_name = "readings"]
+#[diesel(table_name = readings)]
 pub struct Reading {
     pub temperature: Option<f64>,
     pub humidity: Option<f64>,


### PR DESCRIPTION
## Description
Upgrades Diesel to v2.0.0 from v1.4.4.


#### GitHub Issue: Closes #4 

### Changes
* Migrates to using the latest stable version of the Diesel ORM crate, v2.0.0

### Testing Strategy
Use `ambi_mock_client` to test adding a reading.


### Concerns
None