### PR TITLE
Cleans up SSE EventStream loop and ran cargo fmt

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,29 +1,30 @@
-use rocket::{State, Shutdown};
 use rocket::response::status::Created;
-use rocket::response::stream::{EventStream, Event};
+use rocket::response::stream::{Event, EventStream};
 use rocket::serde::json::Json;
 use rocket::tokio::select;
 use rocket::tokio::sync::broadcast::Sender;
 use rocket::tokio::time::{self, Duration};
+use rocket::{Shutdown, State};
 
 use crate::schema::*;
 use crate::PgConnection;
 use diesel::prelude::*;
 
-use crate::models::{Reading, NewReading, ApiError};
+use crate::models::{ApiError, NewReading, Reading};
 
 /// Returns an infinite stream of server-sent events. Each event is a message
 /// pulled from a broadcast queue sent by the `post` handler.
 #[get("/events")]
-pub(crate) async fn events(conn: PgConnection, queue: &State<Sender<Reading>>, mut end: Shutdown) -> EventStream![] {
+pub(crate) async fn events(
+    conn: PgConnection,
+    queue: &State<Sender<Reading>>,
+    mut end: Shutdown,
+) -> EventStream![] {
     let _rx = queue.subscribe();
     std::println!("events()");
     EventStream! {
         let mut interval = time::interval(Duration::from_secs(5));
         loop {
-            //interval.tick().await;
-
-            // Handle graceful shutdown of infinite EventStream
             select! {
                 _ = interval.tick() => {
                     match get_latest_reading(&conn).await {
@@ -38,49 +39,44 @@ pub(crate) async fn events(conn: PgConnection, queue: &State<Sender<Reading>>, m
                         Err(e) => { println!("Err: failed to retrieve latest reading: {:?}", e) }
                     }
                 }
+
+                // Handle graceful shutdown of infinite EventStream
                 _ = &mut end => {
                     println!("EventStream graceful shutdown requested, handling...");
                     break;
                 }
             }
-            // let msg = select! {
-            //     msg = rx.recv() => match msg {
-            //         Ok(msg) => msg,
-            //         Err(RecvError::Closed) => break,
-            //         Err(RecvError::Lagged(_)) => continue,
-            //     },
-            //     _ = &mut end => break,
-            // };
-
-            // std::println!("Subscribed remote client");
-            // yield Event::json(&msg);
         }
     }
 }
 
 async fn get_latest_reading(conn: &PgConnection) -> Result<Reading, Json<ApiError>> {
     // Get the last inserted temperature value
-    let reading = conn.run(move |c| {
-        readings::table
-            .order(readings::id.desc())
-            .first::<Reading>(c)
-    }).await
-    .map(|a| a)
-    .map_err(|e| {
-        Json(ApiError {
-            details: e.to_string(),
+    let reading = conn
+        .run(move |c| {
+            readings::table
+                .order(readings::id.desc())
+                .first::<Reading>(c)
         })
-    });
+        .await
+        .map(|a| a)
+        .map_err(|e| {
+            Json(ApiError {
+                details: e.to_string(),
+            })
+        });
 
     println!("Reading: {:?}", reading);
 
     reading
 }
 
-#[post("/readings/add", data="<reading>")]
-pub(crate) async fn create_reading(conn: PgConnection, reading: Json<NewReading>) -> Result<Created<Json<Reading>>, Json<ApiError>> {
-    conn
-    .run(move |c| {
+#[post("/readings/add", data = "<reading>")]
+pub(crate) async fn create_reading(
+    conn: PgConnection,
+    reading: Json<NewReading>,
+) -> Result<Created<Json<Reading>>, Json<ApiError>> {
+    conn.run(move |c| {
         diesel::insert_into(readings::table)
             .values(&reading.into_inner())
             .get_result(c)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,15 @@ mod controller;
 pub mod models;
 pub mod schema;
 
-#[macro_use] 
+#[macro_use]
 extern crate rocket;
 #[macro_use]
 extern crate diesel;
 
-use rocket::Build;
 use rocket::fs::{relative, FileServer};
-use rocket_sync_db_pools::database;
 use rocket::tokio::sync::broadcast::channel;
+use rocket::Build;
+use rocket_sync_db_pools::database;
 
 use crate::controller::{create_reading, events};
 use crate::models::Reading;
@@ -21,9 +21,9 @@ pub struct PgConnection(diesel::PgConnection);
 #[launch]
 pub fn rocket_builder() -> rocket::Rocket<Build> {
     rocket::build()
-    .attach(PgConnection::fairing())
-    .manage(channel::<Reading>(1024).0)
-    .mount("/", routes![events])
-    .mount("/api", routes![create_reading])
-    .mount("/", FileServer::from(relative!("static")))
+        .attach(PgConnection::fairing())
+        .manage(channel::<Reading>(1024).0)
+        .mount("/", routes![events])
+        .mount("/api", routes![create_reading])
+        .mount("/", FileServer::from(relative!("static")))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use ambi_rs::rocket_builder;
 
 #[rocket::main]
-async fn main() -> Result<(), rocket::Error>{
+async fn main() -> Result<(), rocket::Error> {
     let _ = rocket_builder().launch().await?;
     Ok(())
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
-use serde::{ Serialize, Deserialize};
-use diesel::Insertable;
 use crate::schema::readings;
+use diesel::Insertable;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, Queryable)]
 #[serde(crate = "rocket::serde")]


### PR DESCRIPTION
This PR cleans up SSE EventStream loop code and a long overdue run of `cargo fmt`.