### PR TITLE
Created simple CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: Build & Tests (server)
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_test_run:
+    name: Build and test
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Use cached dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "ubuntu-22.04-x86_64-unknown-linux-gnu"
+
+      - name: Install Diesel CLI
+        run: |
+          apt-get update && install libpq-dev -y
+          cargo install diesel_cli --no-default-features --features postgres
+
+      - name: Build
+        run: cargo build --all-targets
+
+      - name: Test
+        run: cargo test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use cached dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "ubuntu-22.04-x86_64-unknown-linux-gnu"
+
+      - name: Install clippy and rustfmt
+        run: |
+          rustup component add clippy
+          rustup component add rustfmt
+
+      - name: Run clippy
+        run: cargo clippy -- -Dwarnings
+
+      - name: Run fmt
+        run: cargo fmt --check


### PR DESCRIPTION
Right now, the workflow

- installs `libpq-dev` and  `diesel_cli` which are needed for compiling the project.
- builds
- tests
- lints

> **Warning** There currently are no tests in the project!

I usually try to run workflows on windows as well but installing `libpq` does not seem to be doable on windows through the command line, unless I missed something.

I personally like having strict lint and formatting rules as you can see [here](https://github.com/Jim-Hodapp-Coaching/ambi-rs/commit/ebf642fca431b8fd05439796018724cc35c75a0e#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR58-R62). I do realize that not everyone likes these so do let me know if you would want them relaxed or even removed altogether.

I've worked on 2 Rust projects so far on which I spent a decent amount improving their workflows, namely a [lib+bin](https://github.com/AntoniosBarotsis/qr-rs) and a [bin](https://github.com/AntoniosBarotsis/Rss2Email) project. If you find something useful from those workflows, I could make the addition here as well (although keep in mind some of the stuff I did require some PAT to be generated somewhere so there would be the need for more direct communication with some maintainer).

Closes #6.