### PR TITLE
Complete set up commands & put inside a code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ DATABASE_URL=postgres://postgres:postgres@localhost/ambi_rs_dev diesel setup
 
 Now run the DB migrations to complete prepping the DB:
 ```sh
-diesel migration run
+DATABASE_URL=postgres://postgres:postgres@localhost/ambi_rs_dev diesel migration run
 ```
 
 ### Set Up Git Hooks
 
 The Ambi repository makes use of several Git hooks to ensure that code quality standards are met and consistent. To automatically configure these hooks for your local workspace, you can run the following:
 
+``` sh
 ./scripts/create-git-hooks
+```
+
 This will create symlinks to the Git hooks, preserving any hooks that you may have already configured.
 
 ## Running


### PR DESCRIPTION
## Description

Very tiny changes to the README, enhancing the setup section.

#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

No GitHub issue due to the very minor nature of the changes. Let me know if an issue should still be opened.

### Changes
* completing the diesel migration command with the necessary env variable
* wrapping the git hooks script command in a code block to make "click to copy" possible

### Testing Strategy

- [ ] Clone ambi-rs anew
- [ ] Run the commands as show in the old version:
  - [ ] `DATABASE_URL=postgres://postgres:postgres@localhost/ambi_rs_dev diesel setup`
  - [ ] `diesel migration run`
- [ ] There SHOULD be an error about `DATABASE_URL` not being set for the second command
- [ ] Run `DATABASE_URL=postgres://postgres:postgres@localhost/ambi_rs_dev diesel migration run`
- [ ] There SHOULD be no error and the DB migration should complete
